### PR TITLE
Dont require default to main

### DIFF
--- a/tests/fetchers/test_git.py
+++ b/tests/fetchers/test_git.py
@@ -12,7 +12,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="https://github.com/inab/WfExS-backend.git",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -20,7 +19,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="https://github.com/inab/WfExS-backend.git",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -37,7 +35,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
                 repo_url="https://github.com/inab/WfExS-backend.git",
                 repo_type=RepoType.Git,
                 rel_path="workflow_examples/ipc/cosifer_test1_cwl.wfex.stage",
-                tag="main",
             ),
         ),
         (
@@ -45,7 +42,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="git@github.com:inab/WfExS-backend.git",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -53,7 +49,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="git@github.com:inab/WfExS-backend.git",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -70,7 +65,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
                 repo_url="git@github.com:inab/WfExS-backend.git",
                 repo_type=RepoType.Git,
                 rel_path="workflow_examples/ipc/cosifer_test1_cwl.wfex.stage",
-                tag="main",
             ),
         ),
         (
@@ -78,7 +72,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="file:///inab/WfExS-backend/.git",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -86,7 +79,7 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="file:///inab/WfExS-backend/.git",
                 repo_type=RepoType.Git,
-                tag="main",
+                tag=None
             ),
         ),
         (
@@ -103,7 +96,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
                 repo_url="file:///inab/WfExS-backend/.git",
                 repo_type=RepoType.Git,
                 rel_path="workflow_examples/ipc/cosifer_test1_cwl.wfex.stage",
-                tag="main",
             ),
         ),
         (
@@ -119,7 +111,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="git@github.com:inab/WfExS-backend",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -127,7 +118,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="https://github.com/inab/WfExS-backend",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
         (
@@ -135,7 +125,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="file:///inab/WfExS-backend",
                 repo_type=RepoType.Git,
-                tag="main",
             ),
         ),
     ],

--- a/tests/fetchers/test_git.py
+++ b/tests/fetchers/test_git.py
@@ -79,7 +79,6 @@ from wfexs_backend.fetchers.git import guess_git_repo_params
             RemoteRepo(
                 repo_url="file:///inab/WfExS-backend/.git",
                 repo_type=RepoType.Git,
-                tag=None
             ),
         ),
         (

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -379,7 +379,7 @@ def guess_git_repo_params(
     if no repo was found.
     """
     repoURL = None
-    repoTag = "main"
+    repoTag = None
     repoRelPath = None
     repoType: "Optional[RepoType]" = RepoType.Git
 

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -166,7 +166,7 @@ class GitFetcher(AbstractRepoFetcher):
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
             self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
-            if repoTag is not None or repoTag == "None":
+            if repoTag is not None or repoTag != "None":
                 gitclone_params = [
                     self.git_cmd,
                     "clone",
@@ -192,7 +192,7 @@ class GitFetcher(AbstractRepoFetcher):
         elif doUpdate:
             gitclone_params = None
             gitcheckout_params = [self.git_cmd, "pull", "--recurse-submodules"]
-            if repoTag is not None or repoTag == "None":
+            if repoTag is not None or repoTag != "None":
                 gitcheckout_params.extend(["origin", repoTag])
         else:
             doRepoUpdate = False

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -166,7 +166,7 @@ class GitFetcher(AbstractRepoFetcher):
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
             self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
-            if repoTag is not None and repoTag != "None":
+            if repoTag is not None:
                 gitclone_params = [
                     self.git_cmd,
                     "clone",
@@ -192,7 +192,7 @@ class GitFetcher(AbstractRepoFetcher):
         elif doUpdate:
             gitclone_params = None
             gitcheckout_params = [self.git_cmd, "pull", "--recurse-submodules"]
-            if repoTag is not None and repoTag != "None":
+            if repoTag is not None:
                 gitcheckout_params.extend(["origin", repoTag])
         else:
             doRepoUpdate = False

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -380,7 +380,7 @@ def guess_git_repo_params(
     if no repo was found.
     """
     repoURL = None
-    repoTag = None
+    repoTag: "Optional[RepoTag]" = None
     repoRelPath = None
     repoType: "Optional[RepoType]" = RepoType.Git
 

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -165,7 +165,7 @@ class GitFetcher(AbstractRepoFetcher):
         doRepoUpdate = True
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
-            self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
+            self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}, {repoTag != 'None'}")
             if repoTag is not None or repoTag != "None":
                 gitclone_params = [
                     self.git_cmd,

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -165,7 +165,6 @@ class GitFetcher(AbstractRepoFetcher):
         doRepoUpdate = True
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
-            self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
             if repoTag is not None:
                 gitclone_params = [
                     self.git_cmd,

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -165,8 +165,8 @@ class GitFetcher(AbstractRepoFetcher):
         doRepoUpdate = True
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
-            self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}, {repoTag != 'None'}")
-            if repoTag is not None or repoTag != "None":
+            self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
+            if repoTag is not None or repoTag == "None":
                 gitclone_params = [
                     self.git_cmd,
                     "clone",

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -380,7 +380,7 @@ def guess_git_repo_params(
     if no repo was found.
     """
     repoURL = None
-    repoTag: "Optional[RepoTag]" = None
+    repoTag = None
     repoRelPath = None
     repoType: "Optional[RepoType]" = RepoType.Git
 

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -426,7 +426,7 @@ def guess_git_repo_params(
 
     return RemoteRepo(
         repo_url=cast("RepoURL", repoURL),
-        tag=repoTag,
+        tag=cast("Optional[RelPath]", repoTag),
         rel_path=cast("Optional[RelPath]", repoRelPath),
         repo_type=repoType,
     )

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -380,7 +380,7 @@ def guess_git_repo_params(
     if no repo was found.
     """
     repoURL = None
-    repoTag = None
+    repoTag: "Optional[RepoTag]" = None
     repoRelPath = None
     repoType: "Optional[RepoType]" = RepoType.Git
 
@@ -426,7 +426,7 @@ def guess_git_repo_params(
 
     return RemoteRepo(
         repo_url=cast("RepoURL", repoURL),
-        tag=cast("Optional[RepoTag]", repoTag),
+        tag=repoTag,
         rel_path=cast("Optional[RelPath]", repoRelPath),
         repo_type=repoType,
     )

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -165,6 +165,7 @@ class GitFetcher(AbstractRepoFetcher):
         doRepoUpdate = True
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
+            self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
             if repoTag is not None:
                 gitclone_params = [
                     self.git_cmd,

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -425,7 +425,7 @@ def guess_git_repo_params(
 
     return RemoteRepo(
         repo_url=cast("RepoURL", repoURL),
-        tag=cast("Optional[RelPath]", repoTag),
+        tag=cast("Optional[RepoTag]", repoTag),
         rel_path=cast("Optional[RelPath]", repoRelPath),
         repo_type=repoType,
     )

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -166,7 +166,7 @@ class GitFetcher(AbstractRepoFetcher):
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
             self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
-            if repoTag is not None:
+            if repoTag is not None or repoTag != "None":
                 gitclone_params = [
                     self.git_cmd,
                     "clone",

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -192,7 +192,7 @@ class GitFetcher(AbstractRepoFetcher):
         elif doUpdate:
             gitclone_params = None
             gitcheckout_params = [self.git_cmd, "pull", "--recurse-submodules"]
-            if repoTag is not None:
+            if repoTag is not None or repoTag == "None":
                 gitcheckout_params.extend(["origin", repoTag])
         else:
             doRepoUpdate = False

--- a/wfexs_backend/fetchers/git.py
+++ b/wfexs_backend/fetchers/git.py
@@ -166,7 +166,7 @@ class GitFetcher(AbstractRepoFetcher):
         if not os.path.exists(os.path.join(repo_tag_destdir, ".git")):
             # Try cloning the repository without initial checkout
             self.logger.debug(f"repoTag: {repoTag}, type: {type(repoTag)}")
-            if repoTag is not None or repoTag != "None":
+            if repoTag is not None and repoTag != "None":
                 gitclone_params = [
                     self.git_cmd,
                     "clone",
@@ -192,7 +192,7 @@ class GitFetcher(AbstractRepoFetcher):
         elif doUpdate:
             gitclone_params = None
             gitcheckout_params = [self.git_cmd, "pull", "--recurse-submodules"]
-            if repoTag is not None or repoTag != "None":
+            if repoTag is not None and repoTag != "None":
                 gitcheckout_params.extend(["origin", repoTag])
         else:
             doRepoUpdate = False

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -1543,7 +1543,7 @@ class WfExSBackend:
             # It could be even empty!
             if repoRelPath == "":
                 repoRelPath = None
-            self.logger.debug(f"guessedRepo: {guessedRepo}, {type(guessedRepo.tag)}")
+
             repoDir, repoEffectiveCheckout = self.doMaterializeRepo(
                 guessedRepo,
                 doUpdate=ignoreCache,

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -1475,6 +1475,7 @@ class WfExSBackend:
 
             # Trying to be smarter
             guessedRepo = self.guess_repo_params(parsedRepoURL, fail_ok=True)
+            self.logger.debug(f"guessedRepo.tag: {guessedRepo.tag}, {type(guessedRepo.tag)}")
 
             if guessedRepo is not None:
                 if guessedRepo.tag is None and version_id is not None:

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -1475,8 +1475,6 @@ class WfExSBackend:
 
             # Trying to be smarter
             guessedRepo = self.guess_repo_params(parsedRepoURL, fail_ok=True)
-            self.logger.debug(f"guessedRepo.tag: {guessedRepo.tag}, {type(guessedRepo.tag)}")
-            self.logger.debug(f"version_id: {version_id}, {type(version_id)}")
 
             if guessedRepo is not None:
                 if guessedRepo.tag is None and version_id is not None:

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -1476,6 +1476,7 @@ class WfExSBackend:
             # Trying to be smarter
             guessedRepo = self.guess_repo_params(parsedRepoURL, fail_ok=True)
             self.logger.debug(f"guessedRepo.tag: {guessedRepo.tag}, {type(guessedRepo.tag)}")
+            self.logger.debug(f"version_id: {version_id}")
 
             if guessedRepo is not None:
                 if guessedRepo.tag is None and version_id is not None:

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -1476,7 +1476,7 @@ class WfExSBackend:
             # Trying to be smarter
             guessedRepo = self.guess_repo_params(parsedRepoURL, fail_ok=True)
             self.logger.debug(f"guessedRepo.tag: {guessedRepo.tag}, {type(guessedRepo.tag)}")
-            self.logger.debug(f"version_id: {version_id}")
+            self.logger.debug(f"version_id: {version_id}, {type(version_id)}")
 
             if guessedRepo is not None:
                 if guessedRepo.tag is None and version_id is not None:

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -1543,7 +1543,7 @@ class WfExSBackend:
             # It could be even empty!
             if repoRelPath == "":
                 repoRelPath = None
-
+            self.logger.debug(f"guessedRepo: {guessedRepo}, {type(guessedRepo.tag)}")
             repoDir, repoEffectiveCheckout = self.doMaterializeRepo(
                 guessedRepo,
                 doUpdate=ignoreCache,

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -415,7 +415,7 @@ class WF:
             self.creds_config = creds_config
 
             self.id = str(workflow_id)
-            self.version_id = str(version_id)
+            self.version_id = None if version_id is None else str(version_id)
             self.descriptor_type = descriptor_type
             self.params = params
             self.placeholders = placeholders

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -1100,7 +1100,6 @@ class WF:
 
         assert self.metaDir is not None
 
-        self.logger.debug(f"fetchWorkflow version_id: {version_id}, {type(version_id)}")
         repoDir, repo, engineDesc, repoEffectiveCheckout = self.wfexs.cacheWorkflow(
             workflow_id=workflow_id,
             version_id=version_id,
@@ -1201,7 +1200,6 @@ class WF:
         # The engine is populated by self.fetchWorkflow()
         if self.engine is None:
             assert self.id is not None
-            self.logger.debug(f"setupEngine version_id: {self.version_id}, {type(self.version_id)}")
             self.fetchWorkflow(
                 self.id,
                 self.version_id,

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -1100,6 +1100,7 @@ class WF:
 
         assert self.metaDir is not None
 
+        self.logger.debug(f"fetchWorkflow version_id: {version_id}, {type(version_id)}")
         repoDir, repo, engineDesc, repoEffectiveCheckout = self.wfexs.cacheWorkflow(
             workflow_id=workflow_id,
             version_id=version_id,
@@ -1200,6 +1201,7 @@ class WF:
         # The engine is populated by self.fetchWorkflow()
         if self.engine is None:
             assert self.id is not None
+            self.logger.debug(f"setupEngine version_id: {self.version_id}, {type(self.version_id)}")
             self.fetchWorkflow(
                 self.id,
                 self.version_id,


### PR DESCRIPTION
A call to `str` in setting up the `version_id` to be `"None"` when it needed to be `None`. This made some if statements fail or put `'None'` as a branch/tag name when pulling workflows from git. This caused git to fail and prevent simply pulling the default `HEAD` from the tag was `None`.

This PR fixes this issue. Setting `workflow_id` in the stage file to a git source will now stage without necessitating a tag name.