### PR TITLE
Fix podman

### DIFF
--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1061,7 +1061,7 @@ STDERR
                                     self.logger.debug(f"using podman")
                                     cmd_arr.extend(
                                         [
-                                            "--disable-pull",
+                                            # "--disable-pull",
                                             "--podman",
                                         ]
                                     )

--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1062,7 +1062,7 @@ STDERR
                                     cmd_arr.extend(
                                         [
                                             "--disable-pull",
-                                            "--user-space-docker-cmd=/usr/bin/docker",
+                                            "--no-container",
                                             "--podman",
                                         ]
                                     )

--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1047,6 +1047,7 @@ STDERR
                                 == ContainerType.Podman
                             ):
                                 if engineVersion < self.PODMAN_CWLTOOL_VERSION:
+                                    self.logger.debug(f"using user space docker")
                                     if self.container_factory.supportsFeature("userns"):
                                         instEnv["PODMAN_USERNS"] = "keep-id"
                                     cmd_arr.extend(
@@ -1057,6 +1058,7 @@ STDERR
                                         ]
                                     )
                                 else:
+                                    self.logger.debug(f"using podman")
                                     cmd_arr.extend(
                                         [
                                             "--disable-pull",

--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1047,7 +1047,6 @@ STDERR
                                 == ContainerType.Podman
                             ):
                                 if engineVersion < self.PODMAN_CWLTOOL_VERSION:
-                                    self.logger.debug(f"using user space docker")
                                     if self.container_factory.supportsFeature("userns"):
                                         instEnv["PODMAN_USERNS"] = "keep-id"
                                     cmd_arr.extend(
@@ -1058,10 +1057,9 @@ STDERR
                                         ]
                                     )
                                 else:
-                                    self.logger.debug(f"using podman")
                                     cmd_arr.extend(
                                         [
-                                            "--disable-pull",
+                                            # "--disable-pull",
                                             "--podman",
                                         ]
                                     )

--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1062,6 +1062,7 @@ STDERR
                                     cmd_arr.extend(
                                         [
                                             "--disable-pull",
+                                            "--user-space-docker-cmd=/usr/bin/docker",
                                             "--podman",
                                         ]
                                     )

--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1061,7 +1061,7 @@ STDERR
                                     self.logger.debug(f"using podman")
                                     cmd_arr.extend(
                                         [
-                                            # "--disable-pull",
+                                            "--disable-pull",
                                             "--podman",
                                         ]
                                     )

--- a/wfexs_backend/cwl_engine.py
+++ b/wfexs_backend/cwl_engine.py
@@ -1062,7 +1062,6 @@ STDERR
                                     cmd_arr.extend(
                                         [
                                             "--disable-pull",
-                                            "--no-container",
                                             "--podman",
                                         ]
                                     )


### PR DESCRIPTION
# Description
Add a hack to allow `cwltool` to pull images when using podman. When `--disable-pull` is set, `cwltool` cannot find the image. `cwtool` seems to use docker to get the image first, then podman to run.

```Traceback (most recent call last):
  File "/home/ansible/wfexs-backend-test/CWLWorkflowEngine/3.1.20230719185429/lib/python3.10/site-packages/cwltool/job.py", line 771, in run
    self.get_from_requirements(
  File "/home/ansible/wfexs-backend-test/CWLWorkflowEngine/3.1.20230719185429/lib/python3.10/site-packages/cwltool/docker.py", line 225, in get_from_requirements
    raise WorkflowException("Docker image %s not found" % r["dockerImageId"])
cwltool.errors.WorkflowException: Docker image hutchstack/rquest-omop-worker:next not found
ERROR Workflow error:
Docker is not available for this tool, try --no-container to disable Docker, or install a user space Docker replacement like uDocker with --user-space-docker-cmd.: Docker image hutchstack/rquest-omop-worker:next not found
```